### PR TITLE
fix: make CI more generic about testing and installing formula

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,45 +3,24 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  install:
+  tap:
     runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Brew tap
         run: brew tap justintime50/formulas
-      - name: brew install alchemist
-        run: brew install justintime50/formulas/alchemist
-        if: always()
-      - name: brew install burn-notice
-        run: brew install justintime50/formulas/burn-notice
-        if: always()
-      - name: brew install easypost-cli
-        run: brew install justintime50/formulas/easypost-cli
-        if: always()
-      - name: brew install onepass
-        run: brew install justintime50/formulas/onepass
-        if: always()
-      - name: brew install secure-browser-kiosk
-        run: brew install justintime50/formulas/secure-browser-kiosk
-        if: always()
+  install:
+    runs-on: macos-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: brew install all
+        run: brew install --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formulas/*.rb
   audit:
     runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-      - name: brew audit alchemist
-        run: brew audit justintime50/formulas/alchemist
-        if: always()
-      - name: brew audit burn-notice
-        run: brew audit justintime50/formulas/burn-notice
-        if: always()
-      - name: brew audit easypost-cli
-        run: brew audit justintime50/formulas/easypost-cli
-        if: always()
-      - name: brew audit onepass
-        run: brew audit justintime50/formulas/onepass
-        if: always()
-      - name: brew audit secure-browser-kiosk
-        run: brew audit justintime50/formulas/secure-browser-kiosk
-        if: always()
+      - name: brew audit all
+        run: brew audit --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formulas/*.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 1 * * *"
 
 jobs:
   tap:
@@ -28,3 +32,8 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: brew audit formula
         run: brew audit --formula /Users/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb
+      - name: Workflow keepalive
+        uses: gautamkrishnar/keepalive-workflow@master # Creates a dummy commit when the workflow is stale to keep it from being disabled
+        with:
+          committer_username: Justintime50
+          committer_email: 39606064+Justintime50@users.noreply.github.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
   install:
     runs-on: macos-latest
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: brew install formula
@@ -20,6 +22,8 @@ jobs:
   audit:
     runs-on: macos-latest
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: brew audit formula

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: brew install formula
-        run: brew install --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb
+        run: brew install --formula /Users/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb
   audit:
     runs-on: macos-latest
     steps:
@@ -27,4 +27,4 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: brew audit formula
-        run: brew audit --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb
+        run: brew audit --formula /Users/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-      - name: brew install all
-        run: brew install --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formulas/*.rb
+      - name: brew install formula
+        run: brew install --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb
   audit:
     runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-      - name: brew audit all
-        run: brew audit --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formulas/*.rb
+      - name: brew audit formula
+        run: brew audit --formula /home/runner/work/homebrew-formulas/homebrew-formulas/formula/*.rb


### PR DESCRIPTION
- Makes the CI config more generic so it tests all formula and we don't need to explicitly add each one.
- Adds a cron schedule to run CI once a day to check the health of the tap and formula often and warn when something no longer works.